### PR TITLE
Update writetrc.m

### DIFF
--- a/src/shared/writetrc.m
+++ b/src/shared/writetrc.m
@@ -28,7 +28,7 @@ time=markers(:,1);
 DataStartFrame=time(1)*VideoFrameRate+1;
 
 %add frame column
-frameArray=[(time(1)*VideoFrameRate):round(time(end)*VideoFrameRate+1)]';
+frameArray=[(time(1)*VideoFrameRate+1):round(time(end)*VideoFrameRate+1)]';
 
 markers=[frameArray markers];
 

--- a/src/shared/writetrc.m
+++ b/src/shared/writetrc.m
@@ -25,10 +25,10 @@ function []= writetrc(markers,MLabels,VideoFrameRate,FullFileName)
 %%
 
 time=markers(:,1);
-DataStartFrame=time(1)*VideoFrameRate;
+DataStartFrame=time(1)*VideoFrameRate+1;
 
 %add frame column
-frameArray=[(time(1)*VideoFrameRate):round(time(end)*VideoFrameRate)]';
+frameArray=[(time(1)*VideoFrameRate):round(time(end)*VideoFrameRate+1)]';
 
 markers=[frameArray markers];
 


### PR DESCRIPTION
Subsequent editing to the changes suggested for selectionData.m: As the frame number in the trc-file is calculated directly from the time array that was lowered previously by -1, the value of +1 has to be added to compensate for this changes
