### PR TITLE
Update HJCHarrington.m

### DIFF
--- a/src/StaticElaboration/private/HJCHarrington.m
+++ b/src/StaticElaboration/private/HJCHarrington.m
@@ -38,7 +38,7 @@ LPSIS=markers{3}';
 RPSIS=markers{4}';
 
 
-for t=1:length(RASIS)
+for t=1:size(RASIS,2)
 
     %Right-handed Pelvis reference system definition 
     SACRUM(:,t)=(RPSIS(:,t)+LPSIS(:,t))/2;      


### PR DESCRIPTION
Alteration, that ensures correct evaluation of the static trial for all trials regardless the frame number. Before a frame number lower than 3 caused a error in the function and a failure of the evaluation.
